### PR TITLE
fix (client/ModSearchOptions) fixed typo in type of setModLoaderType

### DIFF
--- a/lib/Client/Options/ModSearch/ModSearchOptions.php
+++ b/lib/Client/Options/ModSearch/ModSearchOptions.php
@@ -172,10 +172,10 @@ class ModSearchOptions
     }
 
     /**
-     * @param int|null $modLoaderType
+     * @param ModLoaderType|null $modLoaderType
      * @return $this
      */
-    public function setModLoaderType(?int $modLoaderType): static
+    public function setModLoaderType(?ModLoaderType $modLoaderType): static
     {
         $this->modLoaderType = $modLoaderType;
         return $this;


### PR DESCRIPTION
Fixed error: 
Fatal error: Uncaught TypeError: Aternos\CurseForgeApi\Client\Options\ModSearch\ModSearchOptions::setModLoaderType(): Argument #1 ($modLoaderType) must be of type ?int